### PR TITLE
Adds the option to filter the returned catalog

### DIFF
--- a/ckanext/dcat/controllers.py
+++ b/ckanext/dcat/controllers.py
@@ -39,6 +39,7 @@ class DCATController(BaseController):
         data_dict = {
             'page': toolkit.request.params.get('page'),
             'modified_since': toolkit.request.params.get('modified_since'),
+            'part': toolkit.request.params.get('part'),
             'format': _format,
             'profiles': _profiles,
         }

--- a/ckanext/dcat/logic.py
+++ b/ckanext/dcat/logic.py
@@ -1,5 +1,6 @@
 from __future__ import division
 import math
+from ast import literal_eval
 
 from pylons import config
 from dateutil.parser import parse as dateutil_parse
@@ -116,6 +117,12 @@ def _search_ckan_datasets(context, data_dict):
     if modified_since:
         search_data_dict['fq_list'].append(
             'metadata_modified:[{0} TO NOW]'.format(modified_since))
+
+    part = data_dict.get('part')
+    part_filter = literal_eval(config.get('ckanext.dcat.part.filter'))
+    part = part_filter.get(part, None)
+    if part:
+        search_data_dict['fq_list'].append(part)
 
     query = toolkit.get_action('package_search')(context, search_data_dict)
 

--- a/ckanext/dcat/logic.py
+++ b/ckanext/dcat/logic.py
@@ -104,11 +104,14 @@ def _search_ckan_datasets(context, data_dict):
         'rows': n,
         'start': n * (page - 1),
         'sort': 'metadata_modified desc',
+        'q': data_dict.get('q', '*:*'),
+        'fq': data_dict.get('fq'),
+        'fq_list': [],
+        'group': 'true',
+        'group.field': 'extras_metadata_original_id',
+        'group.main': 'true',
+        'group.sort': 'metadata_created desc'
     }
-
-    search_data_dict['q'] = data_dict.get('q', '*:*')
-    search_data_dict['fq'] = data_dict.get('fq')
-    search_data_dict['fq_list'] = []
 
     # Exclude certain dataset types
     search_data_dict['fq_list'].append('-dataset_type:harvest')

--- a/ckanext/dcat/logic.py
+++ b/ckanext/dcat/logic.py
@@ -164,7 +164,7 @@ def _pagination_info(query, data_dict):
             base_url, toolkit.request.path)
 
         params = [p for p in toolkit.request.params.iteritems()
-                  if p[0] != 'page' and p[0] in ('modified_since', 'profiles', 'q', 'fq')]
+                  if p[0] != 'page' and p[0] in ('modified_since', 'profiles', 'q', 'fq', 'part')]
         if params:
             qs = '&'.join(['{0}={1}'.format(p[0], p[1]) for p in params])
             return '{0}?{1}&page={2}'.format(

--- a/ckanext/dcat/logic.py
+++ b/ckanext/dcat/logic.py
@@ -119,11 +119,14 @@ def _search_ckan_datasets(context, data_dict):
             'metadata_modified:[{0} TO NOW]'.format(modified_since))
 
     part = data_dict.get('part')
-    part_filter = literal_eval(config.get('ckanext.dcat.part.filter'))
-    part = part_filter.get(part, None)
     if part:
-        search_data_dict['fq_list'].append(part)
-
+        try:
+            part_filters = literal_eval(config.get('ckanext.dcat.part.filters'))
+            part_filter = part_filters.get(part)
+            if part_filter:
+                search_data_dict['fq_list'].append(part_filter)
+        except ValueError:
+            pass
     query = toolkit.get_action('package_search')(context, search_data_dict)
 
     return query


### PR DESCRIPTION
Filter in ckan configuration file with for example
ckanext.dcat.part.filters = {'govdata': '(+dataset_type:dataset OR (+dataset_type:document +tags:govdata)) +extras_latestVersion:true'}

Multiple filters can be defined that can be used by calling the catalog with the required parameter.
For example: {ckan-url}/catalog.rdf?part=govdata